### PR TITLE
Save the load status into db

### DIFF
--- a/src/PowerGrid/PowerGridBundle/Command/WatchCommand.php
+++ b/src/PowerGrid/PowerGridBundle/Command/WatchCommand.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace PowerGrid\PowerGridBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand,
+    Symfony\Component\Console\Input\InputInterface,
+    Symfony\Component\Console\Input\InputOption,
+    Symfony\Component\Console\Output\OutputInterface;
+
+use PowerGrid\PowerGridBundle\Entity\Record;
+
+class WatchCommand extends ContainerAwareCommand
+{
+    protected $em;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('power:watch')
+            ->setDescription('Watch the status of the power and save it in the DB')
+            ->addOption(
+               'keep-going',
+               'w', // w = watch
+               InputOption::VALUE_NONE,
+               'Check for load status every x seconds'
+            )
+            ->addOption(
+                'period',
+                NULL,
+                InputOption::VALUE_REQUIRED,
+                'Set the polling period in seconds (used with --keep-going)',
+                30
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ( $input->getOption('keep-going') ) {
+            while ( TRUE )
+            {
+                $this->checkStatus($input, $output);
+
+                sleep($input->getOption('period'));
+            }
+        }
+        else {
+            $this->checkStatus($input, $output);
+        }
+    }
+
+    public function checkStatus(InputInterface $input, OutputInterface $output)
+    {
+        try
+        {
+            $powerGridService = $this->getContainer()->get('power_grid_service');
+            $status = $powerGridService->getStatus();
+
+            if( $status && $status != 'Unknown' )
+            {
+                /** @var $em \Doctrine\ORM\EntityManager */
+                $em = $this->getContainer()->get('doctrine')->getManager();
+
+                // Keep entity manager open
+                if ( ! $em->isOpen() ) {
+                    $em = $em->create(
+                        $em->getConnection(),
+                        $em->getConfiguration()
+                    );
+                }
+
+                $latestRecord = $em->getRepository('PowerGridBundle:Record')
+                    ->getLatestStatus()
+                    ->getQuery()
+                    ->getOneOrNullResult()
+                ;
+
+                // If there is no recors or the latest record is not the same
+                // Than, insert new record
+                if( $latestRecord == NULL || $latestRecord->getStatus() != $status )
+                {
+                    $record = new Record();
+                    $record->setStatus($status);
+                    $em->persist($record);
+                    $em->flush();
+
+                    $output->writeln(sprintf('<info>[%s]</info> NEW STATUS (<info>%s</info>) ...', date('G:i:s'), $status));
+                }
+                else {
+                    $output->writeln(sprintf('<info>[%s]</info> KEEP GOING, NO THING NEW ...', date('G:i:s')));
+                }
+
+                // detach all the entities to enforce loading objects from the
+                // database again instead of serving them from the identity map.
+                $em->clear();
+
+            }
+            else {
+                $output->writeln(sprintf('<info>[%s]</info> UNKNOWN STATUS, TRY AGAIN ...', date('G:i:s')));
+            }
+
+        } catch (\Exception $e) {
+            $this->getContainer()->get('doctrine')->resetManager();
+            $output->writeln(sprintf('<info>[%s]</info> <error>[error]</error> %s', date('G:i:s'), $e->getMessage()));
+        }
+    }
+}
+

--- a/src/PowerGrid/PowerGridBundle/Entity/Record.php
+++ b/src/PowerGrid/PowerGridBundle/Entity/Record.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace PowerGrid\PowerGridBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Record
+ *
+ * @ORM\Table(name="records")
+ * @ORM\Entity(repositoryClass="PowerGrid\PowerGridBundle\Entity\RecordRepository")
+ * @ORM\HasLifecycleCallbacks
+ */
+class Record
+{
+    /**
+     * @var integer
+     *
+     * @ORM\Column(name="id", type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column(name="status", type="string", length=100)
+     */
+    private $status;
+
+    /**
+     * @var \DateTime
+     *
+     * @ORM\Column(name="created_at", type="datetime")
+     */
+    private $createdAt;
+
+
+    /**
+     * Get id
+     *
+     * @return integer
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    // ---------------------------------------------------------------------
+
+    /**
+     * Set status
+     *
+     * @param string $status
+     * @return Record
+     */
+    public function setStatus($status)
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * Get status
+     *
+     * @return string
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    // ---------------------------------------------------------------------
+
+    /**
+     * Set createdAt
+     *
+     * @param \DateTime $createdAt
+     * @return Record
+     */
+    public function setCreatedAt(\DateTime $createdAt)
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
+    }
+
+    /**
+     * Get createdAt
+     *
+     * @return \DateTime
+     */
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
+    }
+
+    // ---------------------------------------------------------------------
+
+    /**
+     * @ORM\PrePersist
+     */
+    public function onPrePersist()
+    {
+        $this->setCreatedAt(new \DateTime());
+    }
+
+    // ---------------------------------------------------------------------
+}

--- a/src/PowerGrid/PowerGridBundle/Entity/RecordRepository.php
+++ b/src/PowerGrid/PowerGridBundle/Entity/RecordRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PowerGrid\PowerGridBundle\Entity;
+
+use Doctrine\ORM\EntityRepository;
+
+class RecordRepository extends EntityRepository
+{
+    public function getLatestStatus()
+    {
+        $QueryBuilder = $this->createQueryBuilder('r');
+
+        $QueryBuilder
+            ->setMaxResults(1)
+            ->addOrderBy('r.createdAt', 'DESC')
+        ;
+
+        return $QueryBuilder;
+    }
+}


### PR DESCRIPTION
I created a console command to fetch the load status and insert it into the database table (records).
The command can be running through cronjob every x minutes 
`*   *   *   *   *   php app/console power:watch`

or by it self
`php app/console power:watch --keep-going --period=30`

...
Now, we need to think about how can we use this data :smiley: 
